### PR TITLE
Enrich the bar calendar email with event info.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+BINARY_NAME := bar-mail-body
+
+build:
+		-mkdir _build
+		go build -ldflags="-extldflags=-static" -o _build/$(BINARY_NAME) ./cmd/main.go
+
+install: build
+		sudo cp _build/$(BINARY_NAME) /usr/local/bin/$(BINARY_NAME)
+		sudo cp bar-mail.sh /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # bar-mail.sh
-Shell script that creates a weekly e-mail for bar shifts
+Shell script that creates a weekly e-mail for bar shifts, but requiring a
+golang build to build the mail body from the c-base calendar.
 
-Copy bar-mail.sh to /usr/local/bin/bar-mail.sh
+Run `make install`
 
 Copy c-base.cron to /etc/cron.d/c-base

--- a/bar-mail.sh
+++ b/bar-mail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# COPY THIS FILE TO: /usr/local/bin/bar-mail.sh
-
 # week2date 2023 14 1 ergibt das Datum (DD.MM.) vom Montag der KW 14,
 # week2date 2023 14 7 liefert das Datum des Sonntags der KW14 zurueck.
 # siehe https://stackoverflow.com/questions/15606567/unix-date-how-to-convert-week-number-date-w-to-a-date-range-mon-sun
@@ -35,45 +33,5 @@ TO=xxx@c-base.org
 # echo $SUB
 # exit 0
 
-cat | mail -s "$SUB" -a "From: vorstand@c-base.org" ${TO} << EOF
-Im folgenden der Barplan fuer naechste Woche. Wer Schichten uebernehmen
-moechte, moege sich bitte einfach eintragen und den Plan als Antwort
-wieder auf die Liste schicken. Die angegebenen Zeiten dienen der
-Orientierung, ihr koennt sie euch gerne anpassen.
-
-Wenn dann jeder nur auf die letzte Mail im Thread antwortet, sollte das
-eigentlich ganz gut funktionieren...
-
-Mo, $MON:
-15:00 -> 20:00:
-19:00 -> 00:30:
-
-Di, $DIE:
-15:00 -> 20:00:
-19:00 -> 00:30:
-
-Mi, $MIT:
-15:00 -> 20:00:
-19:00 -> 00:30:
-
-Do, $DON:
-15:00 -> 20:00:
-19:00 -> 00:30:
-
-Fr, $FRE:
-15:00 -> 20:00:
-19:00 -> 00:30:
-
-Sa, $SAM:
-14:00 -> 20:00:
-19:00 -> 00:30:
-
-So, $SON:
-15:00 -> 20:00:
-19:00 -> 00:30:
-
-
-Dies ist eine automatisch gesendete Nachricht, sie ist
-ohne Unterschrift gueltig.
-EOF
+bar-mail-body | mail '-s' "$SUB" '-a' "From: vorstand@c-base.org" ${TO}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	_ "time/tzdata"
+
+	"github.com/c-base/bar-mail/pkg/barmail"
+)
+
+func main() {
+	err := barmail.GetBarMail()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/c-base/bar-mail
+
+go 1.21.2
+
+require github.com/jinzhu/now v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
+github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=

--- a/pkg/barmail/mail.go
+++ b/pkg/barmail/mail.go
@@ -1,0 +1,118 @@
+package barmail
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/jinzhu/now"
+)
+
+const (
+	mailBody = `Im folgenden der Barplan fuer naechste Woche. Wer Schichten uebernehmen
+moechte, moege sich bitte einfach eintragen und den Plan als Antwort
+wieder auf die Liste schicken. Die angegebenen Zeiten dienen der
+Orientierung, ihr koennt sie euch gerne anpassen.
+
+Wenn dann jeder nur auf die letzte Mail im Thread antwortet, sollte das
+eigentlich ganz gut funktionieren...
+%s
+Dies ist eine automatisch gesendete Nachricht, sie ist
+ohne Unterschrift gueltig.
+`
+
+	day = `
+%s, %s:%s
+15:00 -> 20:00:
+19:00 -> 00:30:
+`
+
+	event = `
+Event: %s, %s`
+)
+
+var days = map[int]string{
+	0: "Mo",
+	1: "Di",
+	2: "Mi",
+	3: "Do",
+	4: "Fr",
+	5: "Sa",
+	6: "So",
+}
+
+type receivedEvents struct {
+	Events   []Event `json:"c_base_events"`
+	Regulars []Event `json:"c_base_regulars"`
+}
+
+type Event struct {
+	Description string    `json:"description"`
+	Title       string    `json:"title"`
+	Start       time.Time `json:"start"`
+}
+
+func (re *receivedEvents) events() []Event {
+	return append(re.Events, re.Regulars...)
+}
+
+func GetBarMail() error {
+	resp, err := http.Get("http://c-base.org/calendar/exported/events.json")
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var cBaseEvents receivedEvents
+	if err := json.Unmarshal(body, &cBaseEvents); err != nil {
+		return err
+	}
+
+	then := time.Now().AddDate(0, 0, 7)
+	now.WeekStartDay = time.Monday
+	start := now.With(then).BeginningOfWeek()
+	end := now.With(then).EndOfWeek()
+
+	var events []Event
+	for _, event := range cBaseEvents.events() {
+		if event.Start.After(start) && event.Start.Before(end) {
+			events = append(events, event)
+		}
+	}
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Start.Before(events[j].Start)
+	})
+
+	mapDays := make(map[int][]Event)
+	for _, event := range events {
+		weekday := int(event.Start.Weekday())
+		if mapDays[weekday] == nil {
+			mapDays[weekday] = []Event{}
+		}
+		mapDays[weekday] = append(mapDays[weekday], event)
+	}
+
+	var dayString string
+	for i := 0; i < 7; i++ {
+		if mapDays[i] == nil {
+			dayString += fmt.Sprintf(day, days[i], start.AddDate(0, 0, i).Format("02.01.2006"), "")
+			continue
+		}
+		var eventStrings string
+		for _, eventData := range mapDays[i] {
+			eventStrings += fmt.Sprintf(event, eventData.Title, eventData.Start.Format("15:04"))
+		}
+		dayString += fmt.Sprintf(day, days[i], start.AddDate(0, 0, i).Format("02.01.2006"), eventStrings)
+	}
+
+	println(fmt.Sprintf(mailBody, dayString))
+	return nil
+}


### PR DESCRIPTION
Adding a golang binary that retrieves the calendar and adds event info to the days of the week.

Example output:
```
Im folgenden der Barplan fuer naechste Woche. Wer Schichten uebernehmen
moechte, moege sich bitte einfach eintragen und den Plan als Antwort
wieder auf die Liste schicken. Die angegebenen Zeiten dienen der
Orientierung, ihr koennt sie euch gerne anpassen.

Wenn dann jeder nur auf die letzte Mail im Thread antwortet, sollte das
eigentlich ganz gut funktionieren...

Mo, 23.10.2023:
15:00 -> 20:00:
19:00 -> 00:30:

Di, 24.10.2023:
Event: Admax-Treffen (intern), 21:00
15:00 -> 20:00:
19:00 -> 00:30:

Mi, 25.10.2023:
Event: NixOS Stammtisch, 19:00
15:00 -> 20:00:
19:00 -> 00:30:

Do, 26.10.2023:
Event: Berlindroid, 19:00
15:00 -> 20:00:
19:00 -> 00:30:

Fr, 27.10.2023:
Event: c-lounge, 20:00
15:00 -> 20:00:
19:00 -> 00:30:

Sa, 28.10.2023:
Event: Biohackers: Cold Plunge, 19:00
15:00 -> 20:00:
19:00 -> 00:30:

So, 29.10.2023:
15:00 -> 20:00:
19:00 -> 00:30:

Dies ist eine automatisch gesendete Nachricht, sie ist
ohne Unterschrift gueltig.
```